### PR TITLE
Fix default value of notification-level

### DIFF
--- a/jenkins_job_wrecker/modules/triggers.py
+++ b/jenkins_job_wrecker/modules/triggers.py
@@ -213,7 +213,7 @@ def gerrittrigger(top, parent):
             gerrit_trigger["skip-vote"] = skip_vote
         elif child.tag == "notificationLevel":
             if child.text is None:
-                gerrit_trigger["notification-level"] = "NONE"
+                gerrit_trigger["notification-level"] = "SERVER_DEFAULT"
             else:
                 gerrit_trigger["notification-level"] = child.text
         elif child.tag == "triggerOnEvents":

--- a/tests/fixtures/triggers/gerrit_trigger.xml
+++ b/tests/fixtures/triggers/gerrit_trigger.xml
@@ -99,5 +99,8 @@
       <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>https://dynamictesturl.com</triggerConfigURL>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
+    <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger plugin="gerrit-trigger@2.30.5">
+      <notificationLevel/>
+    </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </matrix-project>

--- a/tests/fixtures/triggers/gerrit_trigger.yml
+++ b/tests/fixtures/triggers/gerrit_trigger.yml
@@ -77,3 +77,5 @@
         - topic-changed-event
         - wip-state-changed-event
         unstable-message: Build Unstable
+    - gerrit:
+        notification-level: SERVER_DEFAULT


### PR DESCRIPTION
According to the [documentation of Gerrit trigger plugin on JJB](https://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.gerrit), default value of `notification-level` is supposed to be `SERVER_DEFAULT`, Also updated the test case to cover that condition.