### PR TITLE
Fixed handling DisableConcurrentBuildsJobProperty

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -86,9 +86,14 @@ def root_to_yaml(root, name, ignore_actions=False):
             # DisableConcurrentBuildsJobProperty tag for not allowing
             # concurrent builds, but no tag for true. JJB defaults to false,
             # this is to make it true in the event that the tag doesn't exist
-            if not root.find('properties.DisableConcurrentBuildsJobProperty'):
-                conElement = ET.SubElement(root, 'concurrentBuild')
-                conElement.text = 'true'
+            disable_concurrent_tag = \
+                "org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty"
+            properties_element = root.find('properties')
+            if properties_element:
+                if properties_element.find(disable_concurrent_tag):
+                    ET.SubElement(root, 'concurrentBuild').text = 'true'
+                else:
+                    ET.SubElement(root, 'concurrentBuild').text = 'false'
 
         # Handle each top-level XML element with custom modules/functions in
         # modules/handlers.py

--- a/tests/fixtures/handlers/concurrent-build.xml
+++ b/tests/fixtures/handlers/concurrent-build.xml
@@ -1,0 +1,6 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.35">
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
+</flow-definition>

--- a/tests/test_modules_handlers.py
+++ b/tests/test_modules_handlers.py
@@ -27,3 +27,13 @@ class TestCombinationFilter(object):
         dct = yaml.safe_load(yml)
         assert len(dct) == 1
         assert dct[0]['job']['execution-strategy']['combination-filter'] == "(lorem == ipsum)"
+
+class TestConcurrentBuild(object):
+    def test_basic(self):
+        filename = os.path.join(fixtures_path, 'concurrent-build.xml')
+        root = get_xml_root(filename=filename)
+        jobname = "test"
+        yml = root_to_yaml(root, jobname)
+        dct = yaml.safe_load(yml)
+        assert len(dct) == 1
+        assert dct[0]['job']['concurrent'] == False


### PR DESCRIPTION
The implementation was not working, making all the pipeline jobs

```
concurrent: true
```

This commit fixes this problem.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>