### PR TITLE
Updated BuildTimeoutWrapper plugin support

### DIFF
--- a/jenkins_job_wrecker/modules/buildwrappers.py
+++ b/jenkins_job_wrecker/modules/buildwrappers.py
@@ -50,6 +50,7 @@ def buildtimeoutwrapper(top, parent):
     FAIL = 'hudson.plugins.build__timeout.operations.FailOperation'
     DESC = 'hudson.plugins.build__timeout.operations.WriteDescriptionOperation'
     ABORT = 'hudson.plugins.build__timeout.operations.AbortOperation'
+    ABORT_AND_RESTART = 'hudson.plugins.build__timeout.operations.AbortAndRestartOperation'
     ABSOLUTE = 'hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy'
     DEADLINE = 'hudson.plugins.build_timeout.impl.DeadlineTimeOutStrategy'
     ELASTIC = 'hudson.plugins.build_timeout.impl.ElasticTimeOutStrategy'
@@ -101,6 +102,13 @@ def buildtimeoutwrapper(top, parent):
                     description = subelement.find('description')
                     if description is not None:
                         timeout_inject['write-description'] = description.text
+                elif subelement.tag == ABORT_AND_RESTART:
+                    timeout_inject['abort-and-restart'] = True
+                    max_restart = subelement.find('maxRestarts')
+                    if max_restart is not None:
+                        timeout_inject['max-restarts'] = int(max_restart.text)
+                    else:
+                        timeout_inject['max-restarts'] = 0
                 else:
                     raise NotImplementedError("cannot handle "
                                               "XML %s" % subelement.tag)

--- a/tests/fixtures/buildwrappers/build-timeout-wrapper.xml
+++ b/tests/fixtures/buildwrappers/build-timeout-wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <buildWrappers>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.19">
+      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
+        <timeoutMinutes>40</timeoutMinutes>
+      </strategy>
+      <operationList>
+        <hudson.plugins.build__timeout.operations.AbortAndRestartOperation>
+          <maxRestarts>2</maxRestarts>
+        </hudson.plugins.build__timeout.operations.AbortAndRestartOperation>
+      </operationList>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+  </buildWrappers>
+</project>

--- a/tests/fixtures/buildwrappers/build-timeout-wrapper.yml
+++ b/tests/fixtures/buildwrappers/build-timeout-wrapper.yml
@@ -1,0 +1,9 @@
+- job:
+    name: build-timeout-wrapper
+    project-type: freestyle
+    wrappers:
+    - timeout:
+        abort-and-restart: true
+        max-restarts: 2
+        timeout: 40
+        type: absolute

--- a/tests/test_modules_buildwrappers.py
+++ b/tests/test_modules_buildwrappers.py
@@ -38,7 +38,11 @@ class TestPreBuildCleanup(object):
         assert 'check-parameter' not in jjb_ws_cleanup
 
 
-
 class TestBuildName(object):
     def test_build_name(self):
         compare_jjb_output(fixtures_path, "build-name", "build-name")
+
+
+class TestBuildTimeoutWrapper(object):
+    def test_build_name(self):
+        compare_jjb_output(fixtures_path, "build-timeout-wrapper", "build-timeout-wrapper")


### PR DESCRIPTION
AbortAndRestart option was missing, necessary implementation is
done.

A test case to verify the change has been implemented.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>